### PR TITLE
Change logo on projects page from MLH Fellowship to Prep

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -6,7 +6,7 @@ layout: default
     <div class="container">
         <div class="logo">
             <a href="/">
-                <img class="w-100" src="/assets/img/mlh-prep.png"/>
+                <img class="w-100 mh-100" src="/assets/img/mlh-prep.png" max-width="180px" max-height="60px" alt="mlh prep program logo"/>
             </a>
         </div>
         <div class="title">

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -6,7 +6,7 @@ layout: default
     <div class="container">
         <div class="logo">
             <a href="/">
-                <img src="/assets/img/logo.svg"/>
+                <img class="w-100" src="/assets/img/mlh-prep.png"/>
             </a>
         </div>
         <div class="title">


### PR DESCRIPTION
## Please, go through these steps before you submit a PR.

- [X] My Pod Leader knows I'm working on this Pull Request
- [X] I've explained what the Pull Request is adding.
- [X] I've explained why this is important.

This pull request is changing the MLH Fellowship logo (svg) to the MLH Prep logo (png). This is important because the prep logo is used on the home page, and there should be consistency throughout the site.

I changed it by changing logo.svg to mlh-prep.png. Since they are different formats, the new logo needed to be resized to fit properly. I used the class "w-100" from Bootstrap to make the width 100% of the area and fit in above "Projects" properly.

Wide screen
![Screen Shot 2022-03-08 at 10 09 12 PM](https://user-images.githubusercontent.com/45278655/157254199-b0dc3bc6-245e-4d97-95e0-ecb06b1b119b.png)

Mid-size screen
<img width="1133" alt="Screen Shot 2022-03-08 at 9 54 03 PM" src="https://user-images.githubusercontent.com/45278655/157251585-e64ba207-9a71-4d49-879e-abf72fa05baf.png">

Narrow screen
<img width="612" alt="Screen Shot 2022-03-08 at 10 08 12 PM" src="https://user-images.githubusercontent.com/45278655/157254161-3547d223-9ff9-4a04-b8e5-69209d04b517.png">

